### PR TITLE
refactor: use qv/non qv mode on poll creation

### DIFF
--- a/packages/hardhat/constants.ts
+++ b/packages/hardhat/constants.ts
@@ -9,11 +9,9 @@ export const intStateTreeDepth = 1;
 export const messageTreeDepth = 2;
 export const voteOptionTreeDepth = 2;
 export const messageBatchDepth = 1;
-export const useQuadraticVoting = true;
 
-export const processMessagesZkeyPath = useQuadraticVoting
-  ? "./zkeys/ProcessMessages_10-2-1-2_test/ProcessMessages_10-2-1-2_test.0.zkey"
-  : "./zkeys/ProcessMessagesNonQv_10-2-1-2_test/ProcessMessagesNonQv_10-2-1-2_test.0.zkey";
-export const tallyVotesZkeyPath = useQuadraticVoting
-  ? "./zkeys/TallyVotes_10-1-2_test/TallyVotes_10-1-2_test.0.zkey"
-  : "./zkeys/TallyVotesNonQv_10-1-2_test/TallyVotesNonQv_10-1-2_test.0.zkey";
+export const processMessagesZkeyPath = "./zkeys/ProcessMessages_10-2-1-2_test/ProcessMessages_10-2-1-2_test.0.zkey";
+export const processMessagesNonQvZkeyPath =
+  "./zkeys/ProcessMessagesNonQv_10-2-1-2_test/ProcessMessagesNonQv_10-2-1-2_test.0.zkey";
+export const tallyVotesZkeyPath = "./zkeys/TallyVotes_10-1-2_test/TallyVotes_10-1-2_test.0.zkey";
+export const tallyVotesNonQvZkeyPath = "./zkeys/TallyVotesNonQv_10-1-2_test/TallyVotesNonQv_10-1-2_test.0.zkey";

--- a/packages/hardhat/contracts/PollManager.sol
+++ b/packages/hardhat/contracts/PollManager.sol
@@ -32,6 +32,7 @@ contract PollManager is Params, DomainObjs {
 	uint256 public totalPolls;
 
 	MACIWrapper public maci;
+	address public owner;
 
 	TreeDepths public treeDepths;
 	PubKey public coordinatorPubKey;
@@ -58,16 +59,13 @@ contract PollManager is Params, DomainObjs {
 	);
 
 	modifier onlyOwner() {
-		require(msg.sender == owner(), "only owner can call this function");
+		require(msg.sender == owner, "only owner can call this function");
 		_;
 	}
 
 	constructor(MACIWrapper _maci) {
 		maci = _maci;
-	}
-
-	function owner() public view returns (address) {
-		return maci.owner();
+	    owner = msg.sender;
 	}
 
 	function setConfig(
@@ -88,7 +86,7 @@ contract PollManager is Params, DomainObjs {
 		string calldata _metadata,
 		uint256 _duration,
 		Mode isQv
-	) public {
+	) public onlyOwner {
 		// TODO: check if the number of options are more than limit
 
 		// deploy the poll contracts

--- a/packages/hardhat/contracts/maci-contracts/MACIWrapper.sol
+++ b/packages/hardhat/contracts/maci-contracts/MACIWrapper.sol
@@ -81,7 +81,6 @@ contract MACIWrapper is MACI {
 		address _vkRegistry,
 		Mode _mode
 	) public override returns (PollContracts memory pollAddr) {
-		// cache the poll to a local variable so we can increment it
 		uint256 pollId = nextPollId;	
 
 		PollContracts memory p = super.deployPoll(

--- a/packages/hardhat/deploy/10_poll_manager.ts
+++ b/packages/hardhat/deploy/10_poll_manager.ts
@@ -55,6 +55,9 @@ const deployContracts: DeployFunction = async function (hre: HardhatRuntimeEnvir
     await verifier.getAddress(),
     await vkRegistry.getAddress(),
   );
+
+  // transfer maci ownership to poll manager
+  await maci.transferOwnership(await pollManager.getAddress());
 };
 
 export default deployContracts;

--- a/packages/nextjs/app/admin/_components/CreatePollModal.tsx
+++ b/packages/nextjs/app/admin/_components/CreatePollModal.tsx
@@ -22,6 +22,7 @@ export default function Example({
     title: "Dummy Title",
     expiry: new Date(),
     pollType: PollType.NOT_SELECTED,
+    mode: EMode.QV,
     options: [""],
   });
   const [isEditingTitle, setIsEditingTitle] = useState<boolean>(false);
@@ -42,6 +43,10 @@ export default function Example({
 
   const handleTitleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setPollData({ ...pollData, title: e.target.value });
+  };
+
+  const handleModeChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    setPollData({ ...pollData, mode: e.target.value === "0" ? EMode.QV : EMode.NON_QV });
   };
 
   const handleEditTitleClick = () => {
@@ -68,7 +73,7 @@ export default function Example({
       pollData.options || [],
       JSON.stringify({ pollType: pollData.pollType }),
       duration > 0 ? BigInt(duration) : 0n,
-      EMode.QV,
+      pollData.mode,
     ],
   });
 
@@ -170,6 +175,17 @@ export default function Example({
         <option value={PollType.SINGLE_VOTE}>Single Candidate Select</option>
         <option value={PollType.MULTIPLE_VOTE}>Multiple Candidate Select</option>
         <option value={PollType.WEIGHTED_MULTIPLE_VOTE}>Weighted-Multiple Candidate Select</option>
+      </select>
+
+      {/* Quadratic Vote or Non Quadratic Vote Selector Here */}
+      <div className="mt-3 mb-2 text-neutral-content">Quadratic Vote or Non Quadratic Vote</div>
+      <select
+        className="select bg-secondary text-neutral w-full rounded-xl"
+        value={pollData.mode}
+        onChange={handleModeChange}
+      >
+        <option value={EMode.QV}>Quadratic Vote</option>
+        <option value={EMode.NON_QV}>Non Quadratic Vote</option>
       </select>
 
       <div className="w-full h-[0.5px] bg-[#3647A4] shadow-2xl my-5" />

--- a/packages/nextjs/contracts/deployedContracts.ts
+++ b/packages/nextjs/contracts/deployedContracts.ts
@@ -1261,7 +1261,7 @@ const deployedContracts = {
       deploymentBlockNumber: 17,
     },
     PollManager: {
-      address: "0x3Aa5ebB10DC797CAC828524e59A333d0A371443c",
+      address: "0x0B306BF915C4d645ff596e518fAf3F9669b97016",
       abi: [
         {
           inputs: [
@@ -1846,7 +1846,7 @@ const deployedContracts = {
       inheritedFunctions: {
         MESSAGE_DATA_LENGTH: "maci-contracts/contracts/utilities/DomainObjs.sol",
       },
-      deploymentBlockNumber: 35,
+      deploymentBlockNumber: 29,
     },
     PoseidonT3: {
       address: "0xDc64a140Aa3E981100a9becA4E685f962f0cF6C9",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2196,7 +2196,6 @@ __metadata:
     eslint-config-next: ^14.0.4
     eslint-config-prettier: ^8.5.0
     eslint-plugin-prettier: ^4.2.1
-    maci-contracts: 0.0.0-ci.f6073a6
     maci-crypto: 0.0.0-ci.f6073a6
     maci-domainobjs: 0.0.0-ci.f6073a6
     next: ^14.0.4


### PR DESCRIPTION
## Description

Use Mode.QV and Mode.NonQV when creating a poll. set multiple zkeys on VkRegistry to accomodate this.

## Additional Information

- [x] I have read the [contributing docs](/scaffold-eth/scaffold-eth-2/blob/main/CONTRIBUTING.md) (if this is your first contribution)
- [x] This is not a duplicate of any [existing pull request](https://github.com/scaffold-eth/scaffold-eth-2/pulls)



Your ENS/address:
